### PR TITLE
fix(vercel): correct nodeVersion configuration format

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,9 @@
 {
   "buildCommand": "npm run build",
   "installCommand": "npm ci",
-  "functions": { "nodeVersion": "20.x" }
+  "functions": {
+    "nodeVersion": {
+      "default": "20.x"
+    }
+  }
 }


### PR DESCRIPTION
- Changed nodeVersion from string to object with default property
- Resolves Vercel deployment error: 'functions.nodeVersion should be object'
- Node version remains 20.x