### PR TITLE
fix(vercel): remove nodeVersion configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,4 @@
 {
   "buildCommand": "npm run build",
-  "installCommand": "npm ci",
-  "functions": {
-    "nodeVersion": {
-      "default": "20.x"
-    }
-  }
+  "installCommand": "npm ci"
 }


### PR DESCRIPTION
Removes the unctions.nodeVersion configuration from vercel.json to fix deployment error. Vercel will use its default Node version.