### PR TITLE
Improves type safety and environment compatibility

### DIFF
--- a/app/components/Alert.tsx
+++ b/app/components/Alert.tsx
@@ -35,7 +35,7 @@ export function Alert({
   dismissible = false,
   onDismiss,
   className = '',
-}: AlertProps) {
+}: Readonly<AlertProps>) {
   const baseStyles = 'border px-4 py-3 rounded-md text-sm flex items-start gap-2'
   const styles = `${baseStyles} ${variantStyles[variant]} ${className}`
 

--- a/app/components/Button.tsx
+++ b/app/components/Button.tsx
@@ -44,7 +44,7 @@ export function Button({
   className = '',
   portal = 'customer',
   ...props
-}: ButtonProps) {
+}: Readonly<ButtonProps>) {
   const baseStyles =
     'font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 transition-all duration-150 disabled:opacity-50 disabled:cursor-not-allowed motion-reduce:transition-none'
   const styles =

--- a/app/components/ErrorBoundary.tsx
+++ b/app/components/ErrorBoundary.tsx
@@ -46,7 +46,7 @@ export class ErrorBoundary extends Component<Props, State> {
                   {this.state.error?.message || 'An unexpected error occurred. Please try refreshing the page.'}
                 </p>
                 <button
-                  onClick={() => window.location.reload()}
+                  onClick={() => globalThis.location.reload()}
                   className="mt-4 px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700"
                 >
                   Refresh Page

--- a/app/components/Input.tsx
+++ b/app/components/Input.tsx
@@ -20,7 +20,7 @@ export function Input({
   className = '',
   id,
   ...props
-}: InputProps) {
+}: Readonly<InputProps>) {
   const normalizedLabel = label?.toLowerCase().replaceAll(/\s+/g, '-')
   const inputId = id || (normalizedLabel ? `input-${normalizedLabel}` : undefined)
   const errorStyles = error

--- a/app/components/Modal.tsx
+++ b/app/components/Modal.tsx
@@ -23,7 +23,7 @@ export function Modal({
   closeOnBackdropClick = true,
   closeOnEscape = true,
   stacking = 0,
-}: ModalProps) {
+}: Readonly<ModalProps>) {
   const modalRef = useRef<HTMLDialogElement>(null)
   const contentRef = useRef<HTMLDivElement>(null)
   const previousFocusRef = useRef<HTMLElement | null>(null)
@@ -50,7 +50,7 @@ export function Modal({
 
   const handleClose = useCallback(() => {
     setIsVisible(false)
-    window.setTimeout(() => {
+    globalThis.setTimeout(() => {
       onClose()
     }, 200)
   }, [onClose])
@@ -80,7 +80,7 @@ export function Modal({
     const modal = modalRef.current
     if (!modal) return
 
-    const timer = window.setTimeout(focusFirstElement, 100)
+    const timer = globalThis.setTimeout(focusFirstElement, 100)
 
     // Trap focus within modal
     const handleTab = (e: KeyboardEvent) => {
@@ -94,7 +94,7 @@ export function Modal({
       if (focusableArray.length === 0) return
 
       const first = focusableArray[0]
-      const last = focusableArray[focusableArray.length - 1]
+      const last = focusableArray.at(-1)
 
       if (e.shiftKey) {
         if (document.activeElement === first) {
@@ -109,7 +109,7 @@ export function Modal({
 
     modal.addEventListener('keydown', handleTab)
     return () => {
-      window.clearTimeout(timer)
+      globalThis.clearTimeout(timer)
       modal.removeEventListener('keydown', handleTab)
       // Restore previous focus
       previousFocusRef.current?.focus()
@@ -163,7 +163,7 @@ export function Modal({
       })
     } else {
       setIsVisible(false)
-      setTimeout(() => {
+      globalThis.setTimeout(() => {
         setIsAnimating(false)
       }, 300) // Wait for exit animation
     }

--- a/app/components/Toast.tsx
+++ b/app/components/Toast.tsx
@@ -18,7 +18,7 @@ interface ToastContainerProps {
 /**
  * Toast notification container
  */
-export function ToastContainer({ toasts, onDismiss }: ToastContainerProps) {
+export function ToastContainer({ toasts, onDismiss }: Readonly<ToastContainerProps>) {
   if (toasts.length === 0) return null
 
   return (
@@ -42,7 +42,7 @@ interface ToastItemProps {
   onDismiss: (id: string) => void
 }
 
-function ToastItem({ toast, onDismiss }: ToastItemProps) {
+function ToastItem({ toast, onDismiss }: Readonly<ToastItemProps>) {
   const [isVisible, setIsVisible] = useState(true)
 
   useEffect(() => {
@@ -79,7 +79,7 @@ export function useToast() {
   const [toasts, setToasts] = useState<Toast[]>([])
 
   const generateId = () => {
-    const webCrypto = typeof globalThis !== 'undefined' ? globalThis.crypto : undefined
+    const webCrypto = typeof globalThis === 'object' && globalThis.crypto ? globalThis.crypto : undefined
     if (webCrypto?.randomUUID) {
       return webCrypto.randomUUID()
     }

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -36,7 +36,7 @@ export async function apiRequest<T = unknown>(
 
   try {
     // Get CSRF token for mutation requests
-    const headers = new Headers(fetchOptions.headers as HeadersInit | undefined)
+    const headers = new Headers(fetchOptions.headers)
 
     if (requireCsrf) {
       const csrfToken = await fetchCsrfToken()

--- a/lib/error-handling.ts
+++ b/lib/error-handling.ts
@@ -15,7 +15,7 @@ export interface ErrorMapping {
 /**
  * Maps technical error messages to user-friendly messages
  */
-export function mapErrorToUserMessage(error: string | Error | unknown): ErrorMapping {
+export function mapErrorToUserMessage(error: unknown): ErrorMapping {
   const errorMessage = error instanceof Error ? error.message : String(error)
   const lowerMessage = errorMessage.toLowerCase()
 

--- a/scripts/backfill-audit-hash.cjs
+++ b/scripts/backfill-audit-hash.cjs
@@ -1,5 +1,5 @@
 const { PrismaClient } = require('@prisma/client');
-const { createHash } = require('crypto');
+const { createHash } = require('node:crypto');
 
 const prisma = new PrismaClient();
 


### PR DESCRIPTION
- Marks component props as readonly to enhance type safety.
- Replaces `window` with `globalThis` for improved compatibility in various JavaScript environments (e.g., Node.js, web workers).
- Uses optional chaining to access `globalThis.crypto` to avoid errors when `crypto` is not available.
- Updates `require('crypto')` to `require('node:crypto')` for Node.js compatibility.