### PR TITLE
fix: add CSRF token fix and payment form validation

### DIFF
--- a/pages/api/csrf.ts
+++ b/pages/api/csrf.ts
@@ -13,5 +13,5 @@ export default function handler(_req: NextApiRequest, res: NextApiResponse) {
     maxAge: 60 * 30, // 30 min
     httpOnly: false, // Allow reading in client for API testing
   }))
-  res.status(200).json({ token })
+  res.status(200).json({ csrfToken: token })
 }


### PR DESCRIPTION
- Fix CSRF endpoint to return csrfToken instead of token
- Add comprehensive client-side validation to payment form
- Display per-field validation errors in real-time
- Block payment submission if validation fails
- Validates: amount, currency, recipient name, account number, SWIFT code, payment reference
- Fixes session expiry issue caused by CSRF token mismatch