### PR TITLE
Simplifies rate limit bypass logic

### DIFF
--- a/lib/rateLimit.ts
+++ b/lib/rateLimit.ts
@@ -15,10 +15,8 @@ function getWindowMs() {
 }
 
 function isBypassed() {
-  return (
-    process.env.DISABLE_RATE_LIMIT === 'true' ||
-    process.env.NODE_ENV === 'test' // tests should not be affected
-  )
+  // Only bypass when explicitly requested via env
+  return process.env.DISABLE_RATE_LIMIT === 'true'
 }
 
 export function rateLimit(key: string) {


### PR DESCRIPTION
Simplifies the rate limit bypass logic by removing the check for `NODE_ENV === 'test'`.

This ensures that rate limiting is only disabled when explicitly requested via the `DISABLE_RATE_LIMIT` environment variable. This prevents unintended bypasses in test environments and provides more consistent rate limiting behavior.