### PR TITLE
security: fix open redirect vulnerability in HTTP redirect server

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -51,7 +51,10 @@ try {
 
   // HTTP redirect server (redirects to HTTPS)
   createHttpServer((req, res) => {
-    res.writeHead(301, { Location: `https://localhost:3443${req.url}` });
+    // Safely construct redirect URL - only use pathname and query, never user input for host
+    const url = new URL(req.url || '/', 'http://localhost');
+    const redirectUrl = `https://localhost:3443${url.pathname}${url.search}`;
+    res.writeHead(301, { Location: redirectUrl });
     res.end();
   }).listen(3000, (err) => {
     if (err) {


### PR DESCRIPTION
Parse URL safely using URL constructor to extract only pathname and query string. Never use raw req.url for redirect location to prevent open redirect attacks.